### PR TITLE
simplify build process using nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ doc/**/*.synctex.gz
 doc/**/figures/*.svg
 doc/**/figures/*.pdf
 src/adhoc*.*
+
+# nix
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708475490,
+        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+  outputs = { nixpkgs, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      daedalus-turbo = (with pkgs; stdenv.mkDerivation {
+          pname = "daedalus-turbo";
+          version = "0.0.0";
+          src = ./.;
+          nativeBuildInputs = [
+            clang
+            cmake
+            pkg-config
+          ];
+          buildInputs = [
+            boost183
+            libsodium
+            spdlog
+            fmt
+            zstd
+          ];
+          installPhase = ''
+            mkdir -p $out/bin
+            cp dt $out/bin
+            ln -s $out/bin/dt $out/bin/daedalus-turbo
+          '';
+        }
+      );
+    in rec {
+      defaultApp = flake-utils.lib.mkApp {
+        drv = defaultPackage;
+      };
+      defaultPackage = daedalus-turbo;
+      devShell = pkgs.mkShell {
+        buildInputs = [
+           daedalus-turbo
+        ];
+      };
+    }
+  );
+}


### PR DESCRIPTION
Makes it easier to use for users that don't have docker installed.

Example Usage:
```
mkdir -p ~/.local/share/daedalus-turbo/data
nix run .# -- sync-http ~/.local/share/daedalus-turbo/data
```